### PR TITLE
fix: verify issuer id matches

### DIFF
--- a/test/__fixtures__/schema1.json
+++ b/test/__fixtures__/schema1.json
@@ -1,5 +1,5 @@
 {
-  "issuerId": "did:web:api.anoncreds.idlab.app:acme",
+  "issuerId": "did:web:ca.dev.2060.io",
   "name": "idlab_demo",
   "version": "0.0.1",
   "attrNames": ["id", "name"]


### PR DESCRIPTION
Verify that the issuerId and the did matches when resolving objects, as otherwise when you extract the `issuerId` from a cred-def / schema the id can be totally different from the did:web, maybe giving a false impression that the credential was issued by another did.